### PR TITLE
Update mdbook and add kroki

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/crc-org/mdbook:0.4.42
+FROM quay.io/crc-org/mdbook:0.4.43
 
 RUN dnf install -y git-core \
     && dnf clean all \

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Build docs
-        run: docker run --rm -v $PWD:/workspace quay.io/crc-org/mdbook:0.4.42 mdbook build
+        run: docker run --rm -v $PWD:/workspace quay.io/crc-org/mdbook:0.4.43 build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example, it is easy to use `.` to start the GitHub Web Editor to read and ed
 To create the HTML output, you can use:
 
 ```
-$ podman run --rm -v $PWD:/workspace quay.io/crc-org/mdbook:0.4.42 mdbook build
+$ podman run --rm -v $PWD:/workspace quay.io/crc-org/mdbook:0.4.43 build
 ```
 
 This will create a `book` folder that contains the output for a static webpage like GitHub Pages.

--- a/book.toml
+++ b/book.toml
@@ -10,3 +10,5 @@ default-theme = "light"
 preferred-dark-theme = "light"
 
 [preprocessor.callouts]
+
+[preprocessor.kroki]

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -1,10 +1,11 @@
 FROM registry.fedoraproject.org/fedora:40 AS builder
 
 
-RUN dnf install -y cargo \
+RUN dnf install -y cargo openssl-devel \
     && cargo install mdbook \
     && cargo install mdbook-callouts \
-    && cargo install mdbook-mermaid
+    && cargo install mdbook-mermaid \
+    && cargo install mdbook-kroki-preprocessor
 
 
 FROM registry.fedoraproject.org/fedora:40 
@@ -12,7 +13,10 @@ FROM registry.fedoraproject.org/fedora:40
 COPY --from=builder /root/.cargo/bin/mdbook /usr/bin
 COPY --from=builder /root/.cargo/bin/mdbook-callouts /usr/bin
 COPY --from=builder /root/.cargo/bin/mdbook-mermaid /usr/bin
+COPY --from=builder /root/.cargo/bin/mdbook-kroki-preprocessor /usr/bin/mdbook-kroki
 
 RUN mkdir -p /workspace
 VOLUME /workspace
 WORKDIR /workspace
+
+ENTRYPOINT ["/usr/bin/mdbook"]

--- a/containers/README.md
+++ b/containers/README.md
@@ -6,8 +6,13 @@ This Fedora container image contains:
 
   - mdBook: https://github.com/rust-lang/mdBook  
     create book from markdown files, like Gitbook
-  - mdBook preprocessor: https://crates.io/crates/mdbook-callouts  
-    to add Obsidian Flavored Markdown's Callouts
+  - mdBook preprocessors:
+    - https://crates.io/crates/mdbook-callouts  
+      to add Obsidian Flavored Markdown's Callouts
+    - https://github.com/badboy/mdbook-mermaid  
+      to add mermaid support
+    - https://github.com/JoelCourtney/mdbook-kroki-preprocessor  
+      to render Kroki diagrams from files or code blocks
 
 
 ## Usage instructions
@@ -15,8 +20,8 @@ Start the container in the folder that contains your documentation source
 
 ```bash
 $ podman run --rm -v $PWD:/workspace \
-    quay.io/crc-org/mdbook:0.4.42 \
-    mdbook build
+    quay.io/crc-org/mdbook:0.4.43 \
+    build
 ```
 
 This will generate a `book` output.
@@ -25,8 +30,8 @@ Or using
 
 ```bash
 $ podman run --rm -v $PWD:/workspace -p 3000:3000 \
-    quay.io/crc-org/mdbook:0.4.42 \
-    mdbook serve
+    quay.io/crc-org/mdbook:0.4.43 \
+    serve
 ```
 
 the generated content will be published using the embedded server on [`http://localhost:3000`](http://localhost:3000)


### PR DESCRIPTION
Awaiting the sync of the image:

 - [ghcr.io/gbraad-redhat/mdbook:0.4.43](http://ghcr.io/gbraad-redhat/mdbook:0.4.43) => [quay.io/crc-org/mdbook:0.4.43](http://quay.io/crc-org/mdbook:0.4.43)

This change adds kroki support to render different diagrams and excalidraw
