### PR TITLE
doc : add instructions in development guide to deal with missing `gpgme` package

### DIFF
--- a/content/Developing.md
+++ b/content/Developing.md
@@ -84,3 +84,36 @@ If you need to update mocks use:
 ```bash
 $ make generate_mocks
 ```
+
+## Troubleshooting errors when running unit tests via IDE
+
+When running tests from IDE, you might encounter this error:
+
+```shell
+pkg-config --cflags -- gpgme
+Package gpgme was not found in the pkg-config search path.
+Perhaps you should add the directory containing `gpgme.pc'
+to the PKG_CONFIG_PATH environment variable
+No package 'gpgme' found
+pkg-config: exit status 1
+```
+
+In order to resolve this you need to install [gpgme](https://github.com/proglottis/gpgme)
+
+### Installing gpgme on Linux
+
+You need to install `libgpgme-dev` using your Linux distribution's package installer tool (`dnf`/`apt`)
+
+Here is an example for Fedora:
+```shell
+sudo dnf -y install libgpgme-dev
+```
+
+### Installing gpgme on MacOS
+
+You need to install `gpgme` on macOS.
+
+Here is an example using homebrew:
+```shell
+brew install gpgme
+```


### PR DESCRIPTION
## Description

While running unit tests from GoLand, I encountered this error multiple times:
```
pkg-config --cflags -- gpgme
Package gpgme was not found in the pkg-config search path.
Perhaps you should add the directory containing `gpgme.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gpgme' found
pkg-config: exit status 1
```

This happens when running unit tests from certain packages (such as `cmd`)

 I thought it's better to document this so that some newcomers don't face this issue.