### PR TITLE
Update (automated) container build to use UBI9, and update mdbook

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/crc-org/mdbook:0.4.43
+FROM ghcr.io/crc-org/mdbook:latest
 
 RUN dnf install -y git-core \
     && dnf clean all \

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,27 @@
+name: Build Container
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Container
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Build container
+        run: |
+          podman build -t ghcr.io/${{ github.repository_owner }}/mdbook:latest \
+            -f containers/Containerfile
+
+      - name: Login to container registry
+        run: |
+          podman login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to registry
+        run: |
+          podman push ghcr.io/${{ github.repository_owner }}/mdbook:latest
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example, it is easy to use `.` to start the GitHub Web Editor to read and ed
 To create the HTML output, you can use:
 
 ```
-$ podman run --rm -v $PWD:/workspace quay.io/crc-org/mdbook:0.4.43 build
+$ podman run --rm -v $PWD:/workspace ghcr.io/crc-org/mdbook:latest build
 ```
 
 This will create a `book` folder that contains the output for a static webpage like GitHub Pages.

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -1,14 +1,14 @@
-FROM registry.fedoraproject.org/fedora:40 AS builder
+FROM registry.access.redhat.com/ubi9:latest AS builder
 
 
 RUN dnf install -y cargo openssl-devel \
-    && cargo install mdbook \
+    && cargo install mdbook --locked \
     && cargo install mdbook-callouts \
     && cargo install mdbook-mermaid \
-    && cargo install mdbook-kroki-preprocessor
+    && cargo install mdbook-kroki-preprocessor --locked
 
 
-FROM registry.fedoraproject.org/fedora:40 
+FROM registry.access.redhat.com/ubi9:latest
 
 COPY --from=builder /root/.cargo/bin/mdbook /usr/bin
 COPY --from=builder /root/.cargo/bin/mdbook-callouts /usr/bin

--- a/content/SUMMARY.md
+++ b/content/SUMMARY.md
@@ -14,7 +14,6 @@ CRC Engineering docs
   - [macOS code signing](macOS-code-signing.md)
   - [Windows installation process](Windows-installation.md)
 - [Networking]()
-  - [Track TCP proxy connections](Using-tcpconnect-to-track-TCP-proxy-connections.md)
   - [User-mode network stack](Usermode-networking-stack.md)
   - [Blocking traffic with nwfilter](Blocking-traffic-with-nwfilter.md)
   - [Using tcpconnect to track TCP proxy connections](Using-tcpconnect-to-track-TCP-proxy-connections.md)


### PR DESCRIPTION
## Summary by Sourcery

Update the mdbook container build to use UBI9 instead of Fedora 40 and migrate image hosting from Quay.io to GitHub Container Registry (GHCR). Add a CI workflow to automate the container build and push process.

Build:
- Switch the container base image from Fedora 40 to UBI9.
- Pin mdbook plugin versions using `--locked` during installation.
- Update the devcontainer definition to use the new container image hosted on GHCR.

CI:
- Add a GitHub Actions workflow to build the container image and push it to GHCR.

Documentation:
- Update the README command examples to use the new container image path on GHCR.